### PR TITLE
Hotfix for jupyter-notebook

### DIFF
--- a/jobs/jupyter-singularity.j2
+++ b/jobs/jupyter-singularity.j2
@@ -20,6 +20,7 @@ echo "{{ log_dir }}/jupyter-${SLURM_JOB_ID}.log" > {{ log_file }}
 
 # Load modules
 source {{ env_file }}
+ml notebook/7.0.2-GCCcore-12.3.0
 
 # Run Jupyter
-singularity run --nv --bind /mnt:/mnt {{ singularity_file }} jupyter notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+singularity run --nv --bind /mnt:/mnt {{ singularity_file }} jupyter-notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}

--- a/jobs/jupyter-singularity.j2
+++ b/jobs/jupyter-singularity.j2
@@ -15,12 +15,20 @@ export PYTHONPATH={{ project_dir }}:$PYTHONPATH
 export BASE_PATH="/mnt/personal/${user}/{{ project_dir }}"
 
 # Paste the node name and job id to the temporary files
-echo ${node} > {{ node_file }}
-echo "{{ log_dir }}/jupyter-${SLURM_JOB_ID}.log" > {{ log_file }}
+echo ${node} node_file }} >{{
+echo "{{ log_dir }}/jupyter-${SLURM_JOB_ID}.log" log_file }} >{{
 
 # Load modules
 source {{ env_file }}
-ml notebook/7.0.2-GCCcore-12.3.0
 
 # Run Jupyter
-singularity run --nv --bind /mnt:/mnt {{ singularity_file }} jupyter-notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+singularity run --nv --bind /mnt:/mnt {{ singularity_file }} bash -c "
+if command -v jupyter &> /dev/null; then
+    jupyter notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+elif command -v jupyter-notebook &> /dev/null; then
+    jupyter-notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+else
+    echo 'Error: Neither jupyter nor jupyter-notebook found inside the container.'
+    exit 1
+fi
+"

--- a/jobs/jupyter.j2
+++ b/jobs/jupyter.j2
@@ -15,13 +15,19 @@ export PYTHONPATH={{ project_dir }}:$PYTHONPATH
 export BASE_PATH="/mnt/personal/${user}/{{ project_name }}"
 
 # Paste the node name and job id to the temporary files
-echo ${node} > {{ node_file }}
-echo "{{ log_dir }}/jupyter-${SLURM_JOB_ID}.log" > {{ log_file }}
+echo ${node} node_file }} >{{
+echo "{{ log_dir }}/jupyter-${SLURM_JOB_ID}.log" log_file }} >{{
 
 # Load modules
 source {{ env_file }}
-ml notebook/7.0.2-GCCcore-12.3.0
 
 # Run Jupyter
 # jupyter notebook --no-browser --port={{ port }} --ip=${node} --NotebookApp.token='' --NotebookApp.password='' --allow-root
-jupyter-notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+if command -v jupyter &>/dev/null; then
+  jupyter notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+elif command -v jupyter-notebook &>/dev/null; then
+  jupyter-notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+else
+  echo "Error: Jupyter is not available in this environment."
+  exit 1
+fi

--- a/jobs/jupyter.j2
+++ b/jobs/jupyter.j2
@@ -9,7 +9,7 @@
 
 node=$(hostname -s)
 user=$(whoami)
-kuceral4
+
 # Add project directory to the python path
 export PYTHONPATH={{ project_dir }}:$PYTHONPATH
 export BASE_PATH="/mnt/personal/${user}/{{ project_name }}"
@@ -20,7 +20,8 @@ echo "{{ log_dir }}/jupyter-${SLURM_JOB_ID}.log" > {{ log_file }}
 
 # Load modules
 source {{ env_file }}
+ml notebook/7.0.2-GCCcore-12.3.0
 
 # Run Jupyter
 # jupyter notebook --no-browser --port={{ port }} --ip=${node} --NotebookApp.token='' --NotebookApp.password='' --allow-root
-jupyter notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}
+jupyter-notebook --no-browser --port={{ port }} --ip=${node} --notebook-dir={{ project_dir }}


### PR DESCRIPTION
This adresses issues with `run-jupyter` command, which currently fails.

The fix is to replace `jupyter notebook` with `jupyter-notebook`. However, a suitable module must be loaded, otherwise the command does not exist.
Module with the newest python (3.11) for this is in  `notebook/7.0.2-GCCcore-12.3.0`, other older python versions are in modules `IPython` up to version 8.5.0 (included), higher versions of this module however do not include the jupyter package.

I do not know the correct way to proceed, so this is only labeled as hotfix and by no means should it become a permanent solution.